### PR TITLE
Add Common Table Expressions (CTE) support

### DIFF
--- a/lib/arel/visitors/amazon_timestream.rb
+++ b/lib/arel/visitors/amazon_timestream.rb
@@ -25,6 +25,12 @@ module Arel
                         end
         collector << relation_name << '.' << quote_column_name(o.name)
       end
+
+      def visit_Arel_Nodes_Cte(o, collector)
+        collector << quote_table_name_without_database(o.name)
+        collector << " AS "
+        visit o.relation, collector
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds [Common Table Expressions (CTE)](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-with) support introduced in Rails 7.1 and supported by [Timestream SQL](https://docs.aws.amazon.com/timestream/latest/developerguide/supported-sql-constructs.SELECT.html).  

Before this patch, queries using `.with(my_cte:)` would default to `WITH "database_name"."my_cte" AS (...)` instead of `WITH "my_cte" AS (...)`, generating an invalid query error from Timestream.