### PR TITLE
Fix query when column type is not string

### DIFF
--- a/lib/active_record/connection_adapters/amazon_timestream_adapter.rb
+++ b/lib/active_record/connection_adapters/amazon_timestream_adapter.rb
@@ -36,7 +36,7 @@ module ActiveRecord
 
     class AmazonTimestreamColumn < Column
       def sql_type
-        @sql_type_metadata.class
+        @sql_type_metadata.type
       end
     end
 


### PR DESCRIPTION
The method `sql_type` is returning `ActiveRecord::ConnectionAdapters::SqlTypeMetadata` class, but it should return the type symbol (`:string`, `:boolean`, etc). Because a class is not expected here, ActiveRecord defaults the column type to String which works for dimensions queries every time, but not measurements that aren't strings.

To reproduce, you can try to query a boolean measurement. Query will raise `Aws::TimestreamQuery::Errors::ValidationException` from Timestream SDK:

```
SELECT ... WHERE "db"."table".my_bool_col = 'true'
Aws::TimestreamQuery::Errors::ValidationException (line 1:365: '=' cannot be applied to boolean, varchar(4)):
```

After the fix, the query will be generated as below:

```
SELECT ... WHERE "db"."table".my_bool_col = true
```